### PR TITLE
- added serial reader

### DIFF
--- a/src/main/java/com/pi4j/catalog/Launcher.java
+++ b/src/main/java/com/pi4j/catalog/Launcher.java
@@ -26,17 +26,18 @@ public final class Launcher implements Runnable {
     public static final List<Application> APPLICATIONS = new ArrayList<Application>(Arrays.asList(
         new SimpleButton_App(),
         new SimpleLED_App(),
-        new LEDButton_App(),
-        new Joystick_App(),
         new ADS1115_App(),
-        new LCDDisplay_App(),
-        new Potentiometer_App(),
-        new JoystickAnalog_App(),
-        new LEDStrip_App(),
-        new LEDMatrix_App(),
         new Buzzer_App(),
-        new Servo_App(),
-        new Camera_App()
+        new Camera_App(),
+        new Joystick_App(),
+        new JoystickAnalog_App(),
+        new LCDDisplay_App(),
+        new LEDButton_App(),
+        new LEDMatrix_App(),
+        new LEDStrip_App(),
+        new Potentiometer_App(),
+        new SerialGps_App(),
+        new Servo_App()
     ));
 
     /**

--- a/src/main/java/com/pi4j/catalog/applications/SerialGps_App.java
+++ b/src/main/java/com/pi4j/catalog/applications/SerialGps_App.java
@@ -1,0 +1,76 @@
+package com.pi4j.catalog.applications;
+
+import com.pi4j.catalog.Application;
+import com.pi4j.catalog.components.SerialReader;
+import com.pi4j.catalog.components.helpers.PrintInfo;
+import com.pi4j.context.Context;
+import com.pi4j.io.serial.FlowControl;
+import com.pi4j.io.serial.Parity;
+import com.pi4j.io.serial.Serial;
+import com.pi4j.io.serial.StopBits;
+import com.pi4j.util.Console;
+
+public class SerialGps_App implements Application {
+    @Override
+    public void execute(Context pi4j) {
+
+        // Create Pi4J console wrapper/helper
+        // (This is a utility class to abstract some of the boilerplate stdin/stdout code)
+        var console = new Console();
+
+        // Print program title/header
+        console.title("<-- The Pi4J Project -->", "Serial Example project");
+
+        // ------------------------------------------------------------
+        // Output Pi4J Context information
+        // ------------------------------------------------------------
+        // The created Pi4J Context initializes platforms, providers
+        // and the I/O registry. To help you to better understand this
+        // approach, we print out the info of these. This can be removed
+        // from your own application.
+        // OPTIONAL
+        PrintInfo.printLoadedPlatforms(console, pi4j);
+        PrintInfo.printDefaultPlatform(console, pi4j);
+        PrintInfo.printProviders(console, pi4j);
+
+        // Here we will create I/O interface for the serial communication.
+        Serial serial = pi4j.create(Serial.newConfigBuilder(pi4j)
+                .use_9600_N81()
+                .dataBits_8()
+                .parity(Parity.NONE)
+                .stopBits(StopBits._1)
+                .flowControl(FlowControl.NONE)
+                .id("my-serial")
+                .device("/dev/ttyS0")
+                .provider("pigpio-serial")
+                .build());
+        serial.open();
+
+        // Wait till the serial port is open
+        console.print("Waiting till serial port is open");
+        while (!serial.isOpen()) {
+            console.print(".");
+            delay(250);
+        }
+        console.println("");
+        console.println("Serial port is open");
+
+        // OPTIONAL: print the registry
+        PrintInfo.printRegistry(console, pi4j);
+
+        // Start a thread to handle the incoming data from the serial port
+        SerialReader serialReader = new SerialReader(console, serial);
+        Thread serialReaderThread = new Thread(serialReader, "SerialReader");
+        serialReaderThread.setDaemon(true);
+        serialReaderThread.start();
+
+        while (serial.isOpen()) {
+            delay(500);
+        }
+
+        serialReader.stopReading();
+
+        console.println("Serial is no longer open");
+
+    }
+}

--- a/src/main/java/com/pi4j/catalog/components/SerialReader.java
+++ b/src/main/java/com/pi4j/catalog/components/SerialReader.java
@@ -1,0 +1,62 @@
+package com.pi4j.catalog.components;
+
+import com.pi4j.io.serial.Serial;
+import com.pi4j.util.Console;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+public class SerialReader implements Runnable {
+
+    private final Console console;
+    private final Serial serial;
+
+    private boolean continueReading = true;
+
+    public SerialReader(Console console, Serial serial) {
+        this.console = console;
+        this.serial = serial;
+    }
+
+    public void stopReading() {
+        continueReading = false;
+    }
+
+    @Override
+    public void run() {
+        // We use a buffered reader to handle the data received from the serial port
+        BufferedReader br = new BufferedReader(new InputStreamReader(serial.getInputStream()));
+
+        try {
+            // Data from the GPS is recieved in lines
+            String line = "";
+
+            // Read data until the flag is false
+            while (continueReading) {
+                // First we need to check if there is data available to read.
+                // The read() command for pigio-serial is a NON-BLOCKING call, in contrast to typical java input streams.
+                var available = serial.available();
+                if (available > 0) {
+                    for (int i = 0; i < available; i++) {
+                        byte b = (byte) br.read();
+                        if (b < 32) {
+                            // All non-string bytes are handled as line breaks
+                            if (!line.isEmpty()) {
+                                // Here we should add code to parse the data to a GPS data object
+                                console.println("Data: '" + line + "'");
+                                line = "";
+                            }
+                        } else {
+                            line += (char) b;
+                        }
+                    }
+                } else {
+                    Thread.sleep(10);
+                }
+            }
+        } catch (Exception e) {
+            console.println("Error reading data from serial: " + e.getMessage());
+            System.out.println(e.getStackTrace());
+        }
+    }
+}

--- a/src/main/java/com/pi4j/catalog/components/helpers/PrintInfo.java
+++ b/src/main/java/com/pi4j/catalog/components/helpers/PrintInfo.java
@@ -1,0 +1,127 @@
+package com.pi4j.catalog.components.helpers;
+
+import com.pi4j.context.Context;
+import com.pi4j.platform.Platform;
+import com.pi4j.platform.Platforms;
+import com.pi4j.provider.Providers;
+import com.pi4j.registry.Registry;
+import com.pi4j.util.Console;
+
+/**
+ * Helper class to output info about the Pi4J {@link Context}.
+ * <p>
+ * After we initialize Pi4J, we can access the following core parts of the system:
+ * <ul>
+ *     <li>Platforms</li>
+ *     <li>Platform (Default Runtime Platform)</li>
+ *     <li>Providers (I/O Providers)</li>
+ *     <li>Registry (I/O Registry)</li>
+ * </ul>
+ */
+public class PrintInfo {
+
+    /**
+     * Pi4J Platforms.
+     * <p>Platforms are intended to represent the hardware platform where Pi4J is running.  In most cases this will be
+     * the 'RaspberryPi' platform, but Pi4J supports and extensible set of platforms thus additional platforms such as
+     * 'BananaPi', 'Odroid', etc can be added.
+     * </p>
+     * <p>Platforms represent the physical layout of a system's hardware I/O
+     * capabilities and what I/O providers the target platform supports.  For example, a 'RaspberryPi' platform supports
+     * `Digital` inputs and outputs, PWM, I2C, SPI, and Serial but does not support a default provider for 'Analog'
+     * inputs and outputs.</p>
+     * <p>Platforms also provide validation for the I/O pins and their capabilities for the target hardware.</p>
+     *
+     * @param console {@link Console}
+     * @param pi4j    {@link Context}
+     */
+    public static void printLoadedPlatforms(Console console, Context pi4j) {
+        Platforms platforms = pi4j.platforms();
+
+        // Let's print out to the console the detected and loaded
+        // platforms that Pi4J detected when it was initialized.
+        console.box("Pi4J PLATFORMS");
+        console.println();
+        platforms.describe().print(System.out);
+        console.println();
+    }
+
+    /**
+     * Pi4J Platform (Default Platform)
+     * <p>A single 'default' platform is auto-assigned during Pi4J initialization based on a weighting value provided
+     * by each platform implementation at runtime. Additionally, you can override this behavior and assign your own
+     * 'default' platform anytime after initialization.</p>
+     * <p>The default platform is a single platform instance from the managed platforms collection that will serve to
+     * define the default I/O providers that Pi4J will use for each given I/O interface when creating and registering
+     * I/O instances.</p>
+     *
+     * @param console {@link Console}
+     * @param pi4j    {@link Context}
+     */
+    public static void printDefaultPlatform(Console console, Context pi4j) {
+        Platform platform = pi4j.platform();
+
+        // Let's print out to the console the detected and loaded
+        // platforms that Pi4J detected when it was initialized.
+        console.box("Pi4J DEFAULT PLATFORM");
+        console.println();
+        platform.describe().print(System.out);
+        console.println();
+    }
+
+    /**
+     * Pi4J Providers
+     * <p>Providers are intended to represent I/O implementations and provide access to the I/O interfaces available on
+     * the system. Providers 'provide' concrete runtime implementations of I/O interfaces such as:
+     * <ul>
+     * <li>DigitalInput</li>
+     * <li>DigitalOutput</li>
+     * <li>AnalogInput</li>
+     * <li>AnalogOutput</li>
+     * <li>PWM</li>
+     * <li>I2C</li>
+     * <li>SPI</li>
+     * <li>SERIAL</li>
+     * </ul></p>
+     * <p>Each platform will have a default set of providers assigned to it to serve as the default providers that
+     * will be used on a given platform's hardware I/O.  However, you are not limited to the providers that a
+     * platform provides, you can instantiate I/O interfaces using any provider that has been registered on the
+     * Pi4J system.  A good example of this is the 'AnalogInput' and 'AnalogOutput' I/O interfaces. The
+     * 'RaspberryPi' does not inherently support analog I/O hardware, but with an attached ADC (Analog to Digital
+     * Converter) or DAC (Digital to Analog converter) chip attached to a data bus (I2C/SPI) you may wish to use
+     * Pi4J to read/write to these analog hardware interfaces.</p>
+     * <p>Providers allow for a completely flexible and extensible infrastructure enabling third-parties to build and
+     * extend the capabilities of Pi4J by writing your/their own Provider implementation libraries.</p>
+     *
+     * @param console {@link Console}
+     * @param pi4j    {@link Context}
+     */
+    public static void printProviders(Console console, Context pi4j) {
+        Providers providers = pi4j.providers();
+
+        // Let's print out to the console the detected and loaded
+        // providers that Pi4J detected when it was initialized.
+        console.box("Pi4J PROVIDERS");
+        console.println();
+        providers.describe().print(System.out);
+        console.println();
+    }
+
+    /**
+     * Pi4J Registry
+     * <p>The registry stores the state of all the I/O managed by Pi4J.</p>
+     *
+     * @param console {@link Console}
+     * @param pi4j    {@link Context}
+     */
+    public static void printRegistry(Console console, Context pi4j) {
+        Registry registry = pi4j.registry();
+
+        // Let's print out to the console the detected and loaded
+        // I/O interfaces registered with Pi4J and included in the 'Registry'.
+        console.box("Pi4J REGISTRY");
+        console.println();
+        registry.describe().print(System.out);
+        console.println();
+    }
+}


### PR DESCRIPTION
At the beginning of the project we deleted the SerialGps application with the Serial class from the library, because we thought it was not used anywhere.
Frank alerted us during after the pullrequest that the code was linked on the Pi4J website and now an error 404 occurs. 
For a first immediate action we made the code available again as a demo application via the launcher.
In P6 we can decide if we add the components to the catalog (GPS tracker would be a good extension to the catalog) or if we make the code available in the community area.

the code is linked in the first comment box. [https://pi4j.com/documentation/io-examples/serial/]

The next step is to adjust the existing link on the web page to the new link in the repo