### PR TITLE
lcd: fix too much trailing spaces

### DIFF
--- a/src/main/java/com/pi4j/catalog/components/LcdDisplay.java
+++ b/src/main/java/com/pi4j/catalog/components/LcdDisplay.java
@@ -202,7 +202,7 @@ public class LcdDisplay extends I2CDevice {
             for (char character : text.toCharArray()) {
                 writeCharacter(character);
             }
-            for(int i = 0; i< columns - text.length(); i++){
+            for(int i = 0; i < columns - text.length() - position; i++){
                 writeCharacter(' ');
             }
         }


### PR DESCRIPTION
Fixes an overflow issue on the lcd where spaces would overwrite other lines